### PR TITLE
Add `use feature' to avoid a bizarre error on Perl 5.10.

### DIFF
--- a/lib/Pod/Weaver/Section/AllowOverride.pm
+++ b/lib/Pod/Weaver/Section/AllowOverride.pm
@@ -18,6 +18,7 @@ package Pod::Weaver::Section::AllowOverride;
 #---------------------------------------------------------------------
 
 use 5.010;
+use feature qw(:5.10);
 use Moose;
 with qw(Pod::Weaver::Role::Transformer Pod::Weaver::Role::Section);
 


### PR DESCRIPTION
Hi, I have used your module Pod::Weaver::Section::AllowOverride in my Dist::Zilla plugin bundle. I found, only on Perl 5.10, a bizarre error occurs like https://travis-ci.org/yak1ex/String-Unescape/jobs/24323913.
(5 months ago https://travis-ci.org/yak1ex/String-Unescape/builds/14526417 shows no error)

It is reproduced in my local environment (Cygwin) by the procedure described in https://gist.github.com/yak1ex/c1a5c61eb038892df818

There are some findings:
- `perlbrew exec --with perl-5.10.1 perl -wc .../Pod/Weaver/Section/AllowOverride.pm` shows OK.
- Use via [App::podweaver](https://metacpan.org/release/App-podweaver) like `perlbrew exec --with perl-5.10.1 podweaver` causes NO such an error.

So, using via Dist::Zilla::Plugin::PodWeaver triggers something related with the error.

Interestingly, adding `use feature qw(:5.10);` after `use 5.010;` magically disappears the error, though I can not understand the reason. As far as I understand, `use 5.010;` implicitly includes `use feature qw(:5.10);`. So, the root cause of this behavior exists somewhere else but it looks too difficult for me to track down the root cause...

I know this is a workaround but seems to be not harmful except for verbosity. Could you include this workaround?
